### PR TITLE
fix: PhpDoc blocks and options constants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 dist: trusty
 group: edge
 
+env:
+  global:
+    - XDEBUG_MODE=coverage
+
 php:
   - 7.0
   - 7.1

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,25 @@
     "name": "yriveiro/php-backoff",
     "description": "Simple backoff / retry functionality",
     "type": "library",
-    "keywords": ["exponential backoff", "backoff", "jitter", "retry"],
+    "keywords": [
+        "exponential backoff",
+        "backoff",
+        "jitter",
+        "retry"
+    ],
     "minimum-stability": "stable",
     "license": "MIT",
-    "authors": [{
-        "name": "Yago Riveiro",
-        "email": "yago.riveiro@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Yago Riveiro",
+            "email": "yago.riveiro@gmail.com"
+        },
+        {
+            "name": "Sergey Gripinskiy",
+            "email": "web-architect@mail.ru",
+            "role": "Contributor"
+        }
+    ],
     "require": {
         "php": ">=7.0"
     },

--- a/src/BackoffInterface.php
+++ b/src/BackoffInterface.php
@@ -1,13 +1,69 @@
 <?php
+
 namespace Yriveiro\Backoff;
+
+use InvalidArgumentException;
 
 interface BackoffInterface
 {
+    const OPTION_CAP = 'cap';
+
+    const OPTION_MAX_ATTEMPTS = 'maxAttempts';
+
+    /**
+     * Returns an array of Configuration.
+     *
+     * cap:          Max duration allowed (in microseconds). If backoff duration
+     *               is greater than cap, cap is returned.
+     * maxAttempts:  Number of attempts before thrown an \Yriveiro\Backoff\BackoffException.
+     *
+     * @return array
+     */
     public static function getDefaultOptions(): array;
 
+    /**
+     * Allows overwrite default option values.
+     *
+     * @param array $options configuration options
+     *
+     * @return BackoffInterface
+     */
+    public function setOptions(array $options): BackoffInterface;
+
+    /**
+     * Exponential backoff algorithm.
+     *
+     * c = attempt
+     *
+     * E(c) = (2**c - 1)
+     *
+     * @param int $attempt attempt number
+     *
+     * @throws InvalidArgumentException
+     * @throws BackoffException
+     * @return float Time to sleep in microseconds before a new retry. The value
+     *               is in microseconds to use with usleep, sleep function only
+     *               works with seconds
+     */
     public function exponential(int $attempt): float;
 
+    /**
+     * This method adds a half jitter value to exponential backoff value.
+     *
+     * @param int $attempt attempt number
+     *
+     * @throws BackoffException
+     * @return int
+     */
     public function equalJitter(int $attempt): int;
 
+    /**
+     * This method adds a jitter value to exponential backoff value.
+     *
+     * @param int $attempt attempt number
+     *
+     * @throws BackoffException
+     * @return int
+     */
     public function fullJitter(int $attempt): int;
 }


### PR DESCRIPTION
- Fixed: not all nessesary '@throws' specified
- All phpDoc blocks pulled up from Backoff to BackoffInterface and '@inheritDoc' is used instead
- Refactoring: all options are moved to constants of BackoffInterface so nobody can ever misspell any option
- Fixed: typo in method name Backoff::maxAttempsExceeded()